### PR TITLE
Removes deprecated svelte in package.json

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -18,12 +18,11 @@
     "vite": "4.3.9"
   },
   "exports": {
-    ".": "./index.js",
+    ".": { svelte: "./index.js" },
     "./SideMenu.svelte": "./SideMenu.svelte",
     "./package.json": "./package.json"
   },
   "name": "@leveluptuts/svelte-side-menu",
-  "svelte": "./index.js",
   "type": "module",
   "version": "1.0.6"
 }


### PR DESCRIPTION
Moves to using an export condition: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition 

Causing this warning in our build:

<img width="1016" alt="Screenshot 2024-03-25 at 11 50 02 AM" src="https://github.com/leveluptuts/svelte-side-menu/assets/176013/564a1e6b-8f47-47eb-a014-1df3439f057a">
